### PR TITLE
Avoid double stringify of config.globals values

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -28,7 +28,7 @@ export default (projectConfig) => {
   const config = mergeConfigs(projectConfig);
 
   // add user defined globals for serverside access
-  each(config.globals, (value, key) => { global[key] = JSON.stringify(value); });
+  each(config.globals, (value, key) => { global[key] = value; });
 
   const errors = validateConfig(config);
 


### PR DESCRIPTION
This PR solves the bug reported in #67

(incoming globals were already `stringify`ed in [`merge-configs.js`](https://github.com/bdefore/universal-redux/blob/master/bin/merge-configs.js#L83))
